### PR TITLE
Fix Typographical Errors in Terms and Conditions Text

### DIFF
--- a/src/screens/TermsConditions/TermsConditions.js
+++ b/src/screens/TermsConditions/TermsConditions.js
@@ -623,7 +623,7 @@ const TermsConditions = () => {
                 send suggstions for creative ideas, design pitch portfolios, or
                 similiar such meterials (“Unsolicited Ideas”). We may currently
                 be developing, have developed, or in the future will develop
-                ideas or materials interally or recieve ideas or materials from
+                ideas or materials interally or receive ideas or materials from
                 other parties that may purely by coincidence be similar to
                 Unsolicited Ideas. If you ignore this policy and send us your
                 Unsolicited Ideas anyway, you grant the Company a non-exclusive,

--- a/src/screens/TermsConditions/TermsConditions.js
+++ b/src/screens/TermsConditions/TermsConditions.js
@@ -621,7 +621,7 @@ const TermsConditions = () => {
                 4.3. Feedback. We welcome feedback, bug reports, comments, and
                 suggestions for improvements to the Services, but please do not
                 send suggstions for creative ideas, design pitch portfolios, or
-                similiar such meterials (“Unsolicited Ideas”). We may currently
+                similiar such materials (“Unsolicited Ideas”). We may currently
                 be developing, have developed, or in the future will develop
                 ideas or materials interally or receive ideas or materials from
                 other parties that may purely by coincidence be similar to


### PR DESCRIPTION


Description:  
This pull request corrects minor typographical errors in the Terms and Conditions screen. Specifically, it updates the spelling of "materials" and "receive" to ensure consistency and accuracy in the feedback section. No functional changes were made; this is a text-only update to improve clarity and professionalism in the user-facing legal text.