### PR TITLE
fix news modal listener leak and sidebar height sync

### DIFF
--- a/src/components/NewsCard/NewsModal.jsx
+++ b/src/components/NewsCard/NewsModal.jsx
@@ -23,23 +23,21 @@ const NewsModal = ({
   const [arrow, setArrow] = useState(false);
 
   useEffect(() => {
-    if (elementRef.current.clientHeight !== 0) {
-      setHeight(elementRef.current.clientHeight);
-    }
     window.scrollTo(0, 0);
-  }, [newsId, content, elementRef.current?.clientHeight]);
+    const el = elementRef.current;
+    if (!el) return;
 
-  const backArrow = document.getElementById("backButton");
+    const updateHeight = () => {
+      if (el.clientHeight !== 0) {
+        setHeight(el.clientHeight);
+      }
+    };
 
-  const setArrowWhite = () => {
-    setArrow(true);
-  };
-  const setArrowBlack = () => {
-    setArrow(false);
-  };
-
-  backArrow?.addEventListener("mouseenter", setArrowWhite);
-  backArrow?.addEventListener("mouseleave", setArrowBlack);
+    updateHeight();
+    const ro = new ResizeObserver(updateHeight);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [newsId, content]);
 
   return (
     <div className="newsModal-wrapper d-flex flex-column flex-xxl-row flex-lg-row gap-3 mb-5">
@@ -48,8 +46,10 @@ const NewsModal = ({
           <div className="d-flex align-items-center gap-2 justify-content-between">
             <button
               className="btn go-back-btn d-flex align-items-center gap-2"
-              id="backButton"
+              type="button"
               onClick={onModalClose}
+              onMouseEnter={() => setArrow(true)}
+              onMouseLeave={() => setArrow(false)}
             >
               <img
                 src={arrow === false ? "https://cdn.worldofdypians.com/wod/goBackArrowBlack.svg" : "https://cdn.worldofdypians.com/wod/goBackArrow.svg"}


### PR DESCRIPTION
## what was wrong
the news detail modal registered mouseenter/mouseleave on the back button from the render path, so every react re-render added more listeners on the same dom node. that grows without bound while you read news or when content updates, and it is easy to end up with duplicated hover behavior.

the effect also depended on `elementRef.current?.clientHeight`, which is unstable as a dependency and does not reliably run when the column height changes after images or html load.

## what this does
- drive the back arrow hover state with normal react `onMouseEnter` / `onMouseLeave` on the button (no imperative dom listeners).
- observe the left column with `ResizeObserver` so the sidebar card slice stays in sync when the article layout changes.
- set `type="button"` on the back control so it never accidentally submits a parent form.

made by mooncitydev
